### PR TITLE
Add music playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
         "fs": "^0.0.1-security",
         "moment-timezone": "^0.6.0",
         "mongoose": "^8.10.1",
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "@discordjs/voice": "^0.18.0",
+        "play-dl": "^1.8.1"
     }
 }

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -1,0 +1,39 @@
+import {
+    SlashCommandBuilder,
+    ApplicationIntegrationType,
+    InteractionContextType,
+    MessageFlags,
+} from "discord.js";
+import { enqueue } from "../../music/player.js";
+import { emojis } from "../../resources/emojis.js";
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName("play")
+        .setDescription("Play music in your voice channel")
+        .setIntegrationTypes([
+            ApplicationIntegrationType.GuildInstall,
+        ])
+        .setContexts([InteractionContextType.Guild])
+        .addStringOption(opt =>
+            opt
+                .setName("query")
+                .setDescription("Song name or URL")
+                .setRequired(true)
+        ),
+
+    async execute({ interaction }) {
+        const member = interaction.member;
+        const voiceChannel = member?.voice?.channel;
+        if (!voiceChannel) {
+            return interaction.reply({
+                content: `${emojis.error} You must be in a voice channel.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
+        await interaction.deferReply();
+        const query = interaction.options.getString("query");
+        await enqueue(voiceChannel, query, interaction, emojis);
+    },
+};

--- a/src/commands/music/stop.js
+++ b/src/commands/music/stop.js
@@ -17,14 +17,13 @@ export default {
         .setContexts([InteractionContextType.Guild]),
 
     async execute({ interaction }) {
-        const connection = interaction.guild ? interaction.guild.id : null;
-        if (!connection) {
+        const didStop = stop(interaction.guildId);
+        if (!didStop) {
             return interaction.reply({
                 content: `${emojis.error} Nothing is playing.`,
                 flags: MessageFlags.Ephemeral,
             });
         }
-        stop(connection);
         return interaction.reply({
             content: `${emojis.reactions.reaction_thumbsup} Stopped playback.`,
             flags: MessageFlags.Ephemeral,

--- a/src/commands/music/stop.js
+++ b/src/commands/music/stop.js
@@ -1,0 +1,33 @@
+import {
+    SlashCommandBuilder,
+    ApplicationIntegrationType,
+    InteractionContextType,
+    MessageFlags,
+} from "discord.js";
+import { stop } from "../../music/player.js";
+import { emojis } from "../../resources/emojis.js";
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName("stop")
+        .setDescription("Stop the music and leave")
+        .setIntegrationTypes([
+            ApplicationIntegrationType.GuildInstall,
+        ])
+        .setContexts([InteractionContextType.Guild]),
+
+    async execute({ interaction }) {
+        const connection = interaction.guild ? interaction.guild.id : null;
+        if (!connection) {
+            return interaction.reply({
+                content: `${emojis.error} Nothing is playing.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+        stop(connection);
+        return interaction.reply({
+            content: `${emojis.reactions.reaction_thumbsup} Stopped playback.`,
+            flags: MessageFlags.Ephemeral,
+        });
+    },
+};

--- a/src/config/clientConfig.js
+++ b/src/config/clientConfig.js
@@ -7,6 +7,7 @@ export const client = new Client({
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.GuildScheduledEvents,
+        GatewayIntentBits.GuildVoiceStates,
     ],
     partials: [Partials.GuildMember, Partials.Message, Partials.Channel],
 });

--- a/src/music/player.js
+++ b/src/music/player.js
@@ -1,0 +1,70 @@
+import { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerStatus, getVoiceConnection, StreamType } from "@discordjs/voice";
+import play from "play-dl";
+
+const queues = new Map(); // guildId -> { connection, player, songs }
+
+async function playNext(guildId) {
+    const queue = queues.get(guildId);
+    if (!queue || queue.songs.length === 0) {
+        if (queue) {
+            queue.connection.destroy();
+            queues.delete(guildId);
+        }
+        return;
+    }
+
+    const song = queue.songs[0];
+    try {
+        const ytInfo = await play.search(song.query, { limit: 1 });
+        if (!ytInfo.length) {
+            song.interaction.followUp({ content: `${song.emojis.error} Couldn't find song.` });
+            queue.songs.shift();
+            return playNext(guildId);
+        }
+        const stream = await play.stream(ytInfo[0].url);
+        const resource = createAudioResource(stream.stream, { inputType: stream.type ?? StreamType.Opus } );
+        queue.player.play(resource);
+        song.interaction.followUp({ content: `${song.emojis.magic} Now playing **${ytInfo[0].title}**` });
+    } catch (err) {
+        console.error('Play error:', err);
+        song.interaction.followUp({ content: `${song.emojis.error} Could not play the requested song.` });
+        queue.songs.shift();
+        return playNext(guildId);
+    }
+}
+
+export async function enqueue(voiceChannel, query, interaction, emojis) {
+    let queue = queues.get(voiceChannel.guild.id);
+    if (!queue) {
+        const connection = joinVoiceChannel({
+            channelId: voiceChannel.id,
+            guildId: voiceChannel.guild.id,
+            adapterCreator: voiceChannel.guild.voiceAdapterCreator,
+        });
+        const player = createAudioPlayer();
+        connection.subscribe(player);
+        player.on(AudioPlayerStatus.Idle, () => {
+            queue.songs.shift();
+            playNext(voiceChannel.guild.id);
+        });
+        queue = { connection, player, songs: [] };
+        queues.set(voiceChannel.guild.id, queue);
+    }
+
+    queue.songs.push({ query, interaction, emojis });
+    if (queue.songs.length === 1) {
+        await playNext(voiceChannel.guild.id);
+    } else {
+        await interaction.followUp({ content: `${emojis.up} Added to queue.` });
+    }
+}
+
+export function stop(guildId) {
+    const queue = queues.get(guildId);
+    if (queue) {
+        queue.songs = [];
+        queue.player.stop(true);
+        queue.connection.destroy();
+        queues.delete(guildId);
+    }
+}


### PR DESCRIPTION
## Summary
- add music playback helper with queue support
- introduce `/play` and `/stop` commands using bot emojis
- include `@discordjs/voice` and `play-dl` dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e6aab5fa883298c1b410286ab0706