### PR TITLE
Potential fix for code scanning alert no. 5: Insecure randomness

### DIFF
--- a/src/utils/ticketControls.ts
+++ b/src/utils/ticketControls.ts
@@ -8,6 +8,7 @@ import {
 	TextDisplayBuilder,
 } from "@minesa-org/mini-interaction";
 import type { MessageActionRowComponent } from "@minesa-org/mini-interaction";
+import { randomInt } from "node:crypto";
 import { db } from "./database.ts";
 import { fetchDiscord } from "./discord.ts";
 import { getEmoji, getEmojiData } from "./emojis.ts";
@@ -394,7 +395,7 @@ export async function getRandomStaffMember(guildId: string, staffRoleId: string)
 		return null;
 	}
 
-	return candidates[Math.floor(Math.random() * candidates.length)];
+	return candidates[randomInt(candidates.length)];
 }
 
 export async function getStaffRoleMembers(guildId: string, staffRoleId: string) {


### PR DESCRIPTION
Potential fix for [https://github.com/minesa-org/kaeru/security/code-scanning/5](https://github.com/minesa-org/kaeru/security/code-scanning/5)

Use a cryptographically secure RNG for index selection instead of `Math.random()`.

Best fix in this file:
- Add a Node.js crypto import (`randomInt`) at the top of `src/utils/ticketControls.ts`.
- In `getRandomStaffMember`, replace:
  - `candidates[Math.floor(Math.random() * candidates.length)]`
  with
  - `candidates[randomInt(candidates.length)]`
  
`crypto.randomInt(max)` returns a uniform integer in `[0, max)`, avoids modulo bias pitfalls from manual byte conversion, and preserves existing behavior (still returns one random candidate or `null` when empty).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
